### PR TITLE
Fix to support an upcoming REDCap update

### DIFF
--- a/Recalculate.php
+++ b/Recalculate.php
@@ -22,7 +22,7 @@ class Recalculate extends AbstractExternalModule
     */
     public function redcap_module_configure_button_display()
     {
-        return $this->isPage('ExternalModules/manager/control_center.php') || $this->userHasRights();
+        return $this->getProjectId() === null || $this->userHasRights();
     }
 
     /*


### PR DESCRIPTION
In an upcoming REDCap update, calls to `redcap_module_configure_button_display()` are being moved into an ajax call, which breaks the `isPage('ExternalModules/manager/control_center.php')` call.  This PR should fix that, and allow us to install this module  at VUMC once this change makes it into the Repo.